### PR TITLE
Fix to Github action workflow

### DIFF
--- a/.github/workflows/publishToNPM.yml
+++ b/.github/workflows/publishToNPM.yml
@@ -19,7 +19,9 @@ jobs:
           npm ci
           npm run build
       - name: Publish @adcaptcha/react to NPM
-        run: npm publish
+        run: |
+          cd packages/react
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Install dependencies and build @adcaptcha/node
@@ -28,6 +30,8 @@ jobs:
           npm ci
           npm run build
       - name: Publish @adcaptcha/node to NPM
-        run: npm publish
+        run: |
+          cd packages/node
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This is quite annoying, I even double checked that when doing cd it keeps the location for the next step was told yes but apparently not after running the Github action again.

```
For the publish step does it have to go into cd packages/node again?

GitHub Copilot
No, it doesn't have to go into cd packages/node again in the publish step. The run commands in GitHub Actions are executed in the same shell for a single job, so the working directory is preserved across steps.

In your case, once you've navigated into packages/node in the "Install dependencies and build @adcaptcha/node" step, you'll still be in that directory in the "Publish @adcaptcha/node to NPM" step. So, you can directly run npm publish without needing to navigate into the directory again.
```