### PR TITLE
feat(react): allow init config

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -18,9 +18,12 @@ A Placement ID is used to specify what media will be shown in a CAPTCHA. To crea
 #### onComplete
 This is a callback that will execute after successfully completing a CAPTCHA. In this example we are using it to get the success token, but can also be used perform different actions e.g. to remove the disabled attribute from submission buttons and change styling rules.
 
+#### config
+An optional configuration object that is passed to the adCAPTCHA widget when it is initialised. This allows you to customise the widget behaviour as documented in the [adCAPTCHA widget configuration guide](https://docs.adcaptcha.com). The TypeScript type `AdCAPTCHAInitConfig` is exported if you want stronger typing for this configuration object.
+
 #### setKeywords
-If you would like to target specific media for a captcha using keywords, you can do this 
-by calling "window.adcap.setKeywords()" with an array of strings. The adCAPTCHA widget 
+If you would like to target specific media for a captcha using keywords, you can do this
+by calling "window.adcap.setKeywords()" with an array of strings. The adCAPTCHA widget
 will then prioritise media that match the keywords you have provided.
 
 Make sure to also add the keywords to the specified media in the [AdCAPTCHA dashboard](https://app.adcaptcha.com/login). 
@@ -45,6 +48,7 @@ function App() {
       <AdCAPTCHA
         placementID={'PLC-01HN2YE5YQACAFM1YEWBDR2419'}
         onComplete={handleComplete}
+        config={{ theme: 'dark' }}
       />
     </div>
   );

--- a/packages/react/src/adCAPTCHA.tsx
+++ b/packages/react/src/adCAPTCHA.tsx
@@ -1,22 +1,25 @@
 import React, { useEffect, useRef } from 'react';
-import { loadScript } from './util';
+import { AdCAPTCHAInitConfig, loadScript } from './util';
 
 interface AdCAPTCHAProps {
   placementID: string;
   onComplete?: () => void;
+  config?: AdCAPTCHAInitConfig;
 }
 
 const AdCAPTCHA = (props: AdCAPTCHAProps) => {
   const onCompleteRef = useRef<(() => void) | undefined>();
   onCompleteRef.current = props.onComplete;
+  const initConfigRef = useRef<AdCAPTCHAInitConfig | undefined>();
+  initConfigRef.current = props.config;
 
   useEffect(() => {
     async function setupTriggers() {
-      loadScript().then(() => {
+      loadScript(initConfigRef.current).then(() => {
         if (!onCompleteRef.current) return;
 
         window.adcap.setupTriggers({
-            onComplete: onCompleteRef.current,
+          onComplete: onCompleteRef.current,
         });
       });
     }

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,1 +1,2 @@
 export { default as AdCAPTCHA, getSuccessToken, setKeywords } from './adCAPTCHA';
+export type { AdCAPTCHAInitConfig } from './util';

--- a/packages/react/src/util.ts
+++ b/packages/react/src/util.ts
@@ -1,15 +1,19 @@
+export interface AdCAPTCHAInitConfig {
+  [key: string]: unknown;
+}
+
 declare global {
   interface Window {
     adcap: {
       setupTriggers: (config: { onComplete: () => void }) => void;
       setKeywords: (keywords: string[]) => void;
-      init: () => void;
+      init: (config?: AdCAPTCHAInitConfig) => void;
       successToken: string;
     };
   }
 }
 
-export function loadScript(): Promise<void> {
+export function loadScript(config?: AdCAPTCHAInitConfig): Promise<void> {
   return new Promise((resolve, reject) => {
     const script = document.createElement('script');
     script.src = "https://widget.adcaptcha.com/index.js";
@@ -17,7 +21,7 @@ export function loadScript(): Promise<void> {
     script.type = 'module';
     script.async = true;
     script.onload = function () {
-      window.adcap.init();
+      window.adcap.init(config);
       resolve();
     };
     script.onerror = reject;

--- a/packages/react/test/adCAPTCHA.spec.tsx
+++ b/packages/react/test/adCAPTCHA.spec.tsx
@@ -1,21 +1,46 @@
 import React from 'react';
-import { render, waitFor, screen } from '@testing-library/react';
-import { default as AdCAPTCHA } from '../src/adCAPTCHA';
+import { render, waitFor } from '@testing-library/react';
+import AdCAPTCHA from '../src/adCAPTCHA';
+import { loadScript } from '../src/util';
 
-jest.mock('../src/adCAPTCHA', () => ({
-  ...jest.requireActual('../src/adCAPTCHA'),
-  loadScript: jest.fn().mockResolvedValue({}),
+jest.mock('../src/util', () => ({
+  loadScript: jest.fn(() => Promise.resolve()),
 }));
 
 describe('AdCAPTCHA', () => {
-  it('renders AdCAPTCHA with the provided placement ID', async () => {
+  const mockedLoadScript = loadScript as jest.MockedFunction<typeof loadScript>;
+
+  beforeEach(() => {
+    mockedLoadScript.mockClear();
+    (window as unknown as { adcap?: typeof window.adcap }).adcap = {
+      setupTriggers: jest.fn(),
+      setKeywords: jest.fn(),
+      init: jest.fn(),
+      successToken: '',
+    } as typeof window.adcap;
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { adcap?: typeof window.adcap }).adcap;
+  });
+
+  it('renders AdCAPTCHA with the provided placement ID', () => {
     const placementID = 'test-placement-id';
-    render(<AdCAPTCHA placementID={placementID} />);
+
+    const { container } = render(<AdCAPTCHA placementID={placementID} />);
+
+    const adCaptchaElement = container.querySelector(`[data-adcaptcha="${placementID}"]`);
+    expect(adCaptchaElement).not.toBeNull();
+  });
+
+  it('initialises the widget with the provided config', async () => {
+    const placementID = 'test-placement-id';
+    const config = { theme: 'dark' };
+
+    render(<AdCAPTCHA placementID={placementID} config={config} />);
 
     await waitFor(() => {
-      const adCaptchaElement = screen.getByTestId('adCaptcha');
-      expect(adCaptchaElement).toBeDefined();
-      expect(adCaptchaElement.getAttribute('data-adcaptcha')).toEqual(placementID);
+      expect(mockedLoadScript).toHaveBeenCalledWith(config);
     });
   });
 });


### PR DESCRIPTION
## Summary
- allow consumers of the React widget to provide an optional configuration object that is passed through to `adcap.init`
- export the configuration type and document the new prop in the README
- update unit tests to cover the configuration flow

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d530fc8c74832aa2098c307cda6a80